### PR TITLE
data validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ A valid spec in JSON form. You can find example Flow-Spec in README of [planer A
 ```javascript=
 {
   "success": true,
-  "id": "<identifier>"
+  "dataset_id": "<dataset-identifier>",
+  "flow_id": "<dataset-identifier-with-revision-number>",
   "errors": [
       "<error-message>"
   ]

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ An API server for managing a Source Spec Registry
 
 state definition:
 
-- `QUEUED`: In the flowmanager, pipeline not created yet
-- `INPROGRESS`: Waiting to run
+- `QUEUED`: Flow created but not running
+- `INPROGRESS`: Flow is running
 - `SUCCEEDED`: Finished successfully
 - `FAILED`: Failed to run
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,33 @@ An API server for managing a Source Spec Registry
   "logs": <full-logs>,
   "error_log": [ <error-log-lines> ],
   "stats": {
-      "bytes": <number>,
-      "count_of_rows": <number>,
-      "dataset_name": <string>,
-      "hash": <datapackage-hash>
+    "bytes": <number>,
+    "count_of_rows": <number>,
+    "dataset_name": <string>,
+    "hash": <datapackage-hash>
+  },
+  "pipelines": {
+    "<pipeline-id-1>": {
+      "title": "Creating CSV",
+      "status": "SUCCEEDED",
+      "stats": null,
+      "error_log": []
+    },
+    "<pipeline-id-2>": {
+      "title": "Creating JSON",
+      "status": "INPROGRESS",
+      "stats": {},
+      "error_log": []
+    },
+    "<pipeline-id-3>": {
+      "title": "Creating ZIP",
+      "status": "FAILED",
+      "stats": {},
+      "error_log": [
+        'error',
+        'logs'
+      ]
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ An API server for managing a Source Spec Registry
 
 ### Status
 
-`/source/{identifier}/status`
+`/source/{owner}/{dataset-id}/{revision-number}`
+
+*Note: Also, you can get info about latest and latest successful revisions by hitting following endpoints*
+
+* latest - `/source/{owner}/{dataset-id}/latest`
+* successful - `/source/{owner}/{dataset-id}/successful`
 
 #### Method
 
@@ -37,64 +42,25 @@ An API server for managing a Source Spec Registry
 
 ```javascript=
 {
-   'state': 'LOADED/REGISTERED/INVALID/RUNNING/SUCCEEDED/FAILED',
-   'logs': [
-              'log-line',
-              'log-line', // ...
-           ],
-   'modified': 'flowmanager-timestamp-of-pipeline-data
-}
-```
-
-### Status
-
-`/source/{identifier}/info`
-
-#### Method
-
-`GET`
-
-#### Response
-
-```javascript=
-{
-  "id": "./<pipeline-id>",
-
-  "pipeline": <pipeline>,
-  "source": <source>,
-
-  "message": <short-message>,
+  "id": "<revision-id>",
+  "spec_contents": <source-specifications>,
+  "modified": <last-modified>,
+  "state": <QUEUED|INPROGRESS|SUCCEEDED|FAILED>,
+  "logs": <full-logs>,
   "error_log": [ <error-log-lines> ],
-  "reason": <full-log>,
-
-  "state": "LOADED/REGISTERED/INVALID/RUNNING/SUCCEEDED/FAILED",
-  "success": <last-run-succeeded?>,
-  "trigger": <dirty-task/scheduled>,
-
   "stats": {
       "bytes": <number>,
       "count_of_rows": <number>,
       "dataset_name": <string>,
       "hash": <datapackage-hash>
-  },
-
-  "cache_hash": "c69ee347c6019eeca4dbf66141001c55",
-  "dirty": false,
-
-  "queued": <numeric-timestamp>,
-  "started": <numeric-timestamp>,
-  "updated": <numeric-timestamp>,
-  "last_success": <numeric-timestamp>,
-  "ended": <numeric-timestamp>
+  }
 }
 ```
 
 state definition:
 
-- `LOADED`: In the flowmanager, pipeline not created yet
-- `REGISTERED`: Waiting to run
-- `INVALID`: Problem with the source spec or the pipeline
-- `RUNNING`: Currently running
+- `QUEUED`: In the flowmanager, pipeline not created yet
+- `INPROGRESS`: Waiting to run
 - `SUCCEEDED`: Finished successfully
 - `FAILED`: Failed to run
 

--- a/flowmanager/blueprint.py
+++ b/flowmanager/blueprint.py
@@ -4,7 +4,7 @@ from flask_jsonpify import jsonpify
 
 from .models import FlowRegistry
 
-from .controllers import upload, update, status, info
+from .controllers import upload, update, info
 from .config import auth_server, db_connection_string
 
 
@@ -20,7 +20,6 @@ def make_blueprint():
 
     # Controller Proxies
     upload_controller = upload
-    status_controller = status
     info_controller = info
     update_controller = update
 
@@ -33,9 +32,6 @@ def make_blueprint():
         contents = request.get_json()
         return jsonpify(update_controller(contents, registry))
 
-    def status_(owner, dataset):
-        return jsonpify(status_controller(owner, dataset, registry))
-
     def info_(owner, dataset):
         return jsonpify(info_controller(owner, dataset, registry))
 
@@ -45,9 +41,7 @@ def make_blueprint():
     blueprint.add_url_rule(
         'update', 'upadte', update_, methods=['POST'])
     blueprint.add_url_rule(
-        '<owner>/<dataset>/info', 'info', info_, methods=['GET'])
-    blueprint.add_url_rule(
-        '<owner>/<dataset>/status', 'status', status_, methods=['GET'])
+        '<owner>/<dataset>/<revision>', 'info', info_, methods=['GET'])
 
     # Return blueprint
     return blueprint

--- a/flowmanager/controllers.py
+++ b/flowmanager/controllers.py
@@ -161,7 +161,7 @@ def update(content, registry: FlowRegistry): #noqa
         if log:
             doc['logs'] = log
         revision = registry.update_revision(flow_id, doc)
-        if flow_status != STATE_PENDING:
+        if (flow_status != STATE_PENDING) and (flow_status != STATE_RUNNING):
             registry.delete_pipelines(flow_id)
 
             dataset = registry.get_dataset(revision['dataset_id'])

--- a/flowmanager/models.py
+++ b/flowmanager/models.py
@@ -269,10 +269,17 @@ class FlowRegistry:
                 flow_id=flow_id, status=STATE_FAILED).first()
             if ret is not None:
                 return STATE_FAILED
-            ret = session.query(Pipelines).filter_by(
+
+            ret_pending = session.query(Pipelines).filter_by(
                 flow_id=flow_id, status=STATE_PENDING).first()
-            if ret is not None:
+            ret_success = session.query(Pipelines).filter_by(
+                flow_id=flow_id, status=STATE_SUCCESS).first()
+            # If not a single success and fail - still queued / pending
+            if (ret_pending is not None) and (ret_pending is None):
                 return STATE_PENDING
+            # If no fail but at least one success - running / in progress
+            if (ret_pending is not None) and (ret_pending is not None):
+                return STATE_RUNNING
             return STATE_SUCCESS
 
     def update_pipeline(self, identifier, doc):

--- a/flowmanager/models.py
+++ b/flowmanager/models.py
@@ -275,10 +275,10 @@ class FlowRegistry:
             ret_success = session.query(Pipelines).filter_by(
                 flow_id=flow_id, status=STATE_SUCCESS).first()
             # If not a single success and fail - still queued / pending
-            if (ret_pending is not None) and (ret_pending is None):
+            if (ret_pending is not None) and (ret_success is None):
                 return STATE_PENDING
             # If no fail but at least one success - running / in progress
-            if (ret_pending is not None) and (ret_pending is not None):
+            if (ret_pending is not None) and (ret_success is not None):
                 return STATE_RUNNING
             return STATE_SUCCESS
 

--- a/flowmanager/models.py
+++ b/flowmanager/models.py
@@ -60,6 +60,7 @@ class DatasetRevision(Base):
     errors = Column(JsonType)
     stats = Column(JsonType)
     logs = Column(JsonType)
+    pipelines = Column(JsonType)
     created_at = Column(DateTime)
     updated_at = Column(DateTime)
 
@@ -68,6 +69,7 @@ class Pipelines(Base):
     __tablename__ = 'pipelines'
     pipeline_id = Column(String(256), primary_key=True)
     flow_id = Column(String(256))
+    title = Column(String(16))
     pipeline_details = Column(JsonType)
     status = Column(String(16))
     errors = Column(JsonType)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -274,19 +274,19 @@ def test_upload_append(full_registry):
         pipelines = list(full_registry.list_pipelines())
         assert len(pipelines) == 8
 
-def test_update_pending(full_registry):
+def test_update_running(full_registry):
     payload = {
       "pipeline_id": "me/id",
-      "event": "progress",
+      "event": "running",
       "success": True,
       "errors": [],
       "log": ["a", "log", "line"]
     }
     ret = update(payload, full_registry)
-    assert ret['status'] == 'pending'
+    assert ret['status'] == 'running'
     assert ret['id'] == 'me/id/1'
     revision = full_registry.get_revision_by_revision_id('me/id/1')
-    assert revision['status'] == 'pending'
+    assert revision['status'] == 'running'
     assert revision['logs'] == ["a", "log", "line"]
 
 def test_update_fail(full_registry):
@@ -320,10 +320,10 @@ def test_update_success(full_registry):
       "errors": []
     }
     ret = update(payload, full_registry)
-    assert ret['status'] == 'pending'
+    assert ret['status'] == 'running'
     assert ret['id'] == 'me/id/1'
     revision = full_registry.get_revision_by_revision_id('me/id/1')
-    assert revision['status'] == 'pending'
+    assert revision['status'] == 'running'
 
     payload = {
       "pipeline_id": "me/id:non-tabular",

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -214,11 +214,11 @@ def test_upload_new(empty_registry: FlowRegistry):
         assert revision['revision'] == 1
         assert revision['status'] == 'pending'
         pipelines = list(empty_registry.list_pipelines_by_id('me/id/1'))
-        assert len(pipelines) == 6
+        assert len(pipelines) == 7
         pipeline = pipelines[0]
         assert pipeline.status == 'pending'
         pipelines = list(empty_registry.list_pipelines())
-        assert len(pipelines) == 6
+        assert len(pipelines) == 7
 
 
 def test_upload_existing(full_registry):
@@ -240,14 +240,14 @@ def test_upload_existing(full_registry):
         assert revision['revision'] == 2
         assert revision['status'] == 'pending'
         pipelines = list(full_registry.list_pipelines_by_id('me/id/2'))
-        assert len(pipelines) == 6
+        assert len(pipelines) == 7
         pipeline = pipelines[0]
         assert pipeline.status == 'pending'
         ## make pipelines for previous revision are still there
         pipelines = list(full_registry.list_pipelines_by_id('me/id/1'))
         assert len(pipelines) == 2
         pipelines = list(full_registry.list_pipelines())
-        assert len(pipelines) == 8
+        assert len(pipelines) == 9
 
 
 def test_upload_append(full_registry):
@@ -275,11 +275,11 @@ def test_upload_append(full_registry):
         assert revision['revision'] == 1
         assert revision['status'] == 'pending'
         pipelines = list(full_registry.list_pipelines_by_id('me2/id2/1'))
-        assert len(pipelines) == 6
+        assert len(pipelines) == 7
         pipelines = list(full_registry.list_pipelines_by_id('me/id/1'))
         assert len(pipelines) == 2
         pipelines = list(full_registry.list_pipelines())
-        assert len(pipelines) == 8
+        assert len(pipelines) == 9
 
 def test_update_running(full_registry):
     payload = {

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -164,7 +164,8 @@ def test_upload_no_contents(empty_registry):
     token = generate_token('me')
     ret = upload(token, None, empty_registry, public_key)
     assert not ret['success']
-    assert ret['id'] is None
+    assert ret['dataset_id'] is None
+    assert ret['flow_id'] is None
     assert ret['errors'] == ['Received empty contents (make sure your content-type is correct)']
 
 
@@ -172,14 +173,16 @@ def test_upload_bad_contents(empty_registry):
     token = generate_token('me')
     ret = upload(token, {}, empty_registry, public_key)
     assert not ret['success']
-    assert ret['id'] is None
+    assert ret['dataset_id'] is None
+    assert ret['flow_id'] is None
     assert ret['errors'] == ['Missing owner in spec']
 
 
 def test_upload_no_token(empty_registry):
     ret = upload(None, spec, empty_registry, public_key)
     assert not ret['success']
-    assert ret['id'] is None
+    assert ret['dataset_id'] is None
+    assert ret['flow_id'] is None
     assert ret['errors'] == ['No token or token not authorised for owner']
 
 
@@ -187,7 +190,8 @@ def test_upload_bad_token(empty_registry):
     token = generate_token('mee')
     ret = upload(token, spec, empty_registry, public_key)
     assert not ret['success']
-    assert ret['id'] is None
+    assert ret['dataset_id'] is None
+    assert ret['flow_id'] is None
     assert ret['errors'] == ['No token or token not authorised for owner']
 
 
@@ -197,7 +201,8 @@ def test_upload_new(empty_registry: FlowRegistry):
         token = generate_token('me')
         ret = upload(token, spec, empty_registry, public_key)
         assert ret['success']
-        assert ret['id'] == 'me/id'
+        assert ret['dataset_id'] == 'me/id'
+        assert ret['flow_id'] == 'me/id/1'
         assert ret['errors'] == []
         specs = list(empty_registry.list_datasets())
         assert len(specs) == 1
@@ -222,7 +227,8 @@ def test_upload_existing(full_registry):
         token = generate_token('me')
         ret = upload(token, spec, full_registry, public_key)
         assert ret['success']
-        assert ret['id'] == 'me/id'
+        assert ret['dataset_id'] == 'me/id'
+        assert ret['flow_id'] == 'me/id/2'
         assert ret['errors'] == []
         specs = list(full_registry.list_datasets())
         assert len(specs) == 2
@@ -250,7 +256,8 @@ def test_upload_append(full_registry):
         token = generate_token('me2')
         ret = upload(token, spec2, full_registry, public_key)
         assert ret['success']
-        assert ret['id'] == 'me2/id2'
+        assert ret['dataset_id'] == 'me2/id2'
+        assert ret['flow_id'] == 'me2/id2/1'
         assert ret['errors'] == []
         specs = list(full_registry.list_datasets())
         assert len(specs) == 3
@@ -277,7 +284,7 @@ def test_upload_append(full_registry):
 def test_update_running(full_registry):
     payload = {
       "pipeline_id": "me/id",
-      "event": "running",
+      "event": "finish",
       "success": True,
       "errors": [],
       "log": ["a", "log", "line"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -61,10 +61,10 @@ class ModelsTestCase(unittest.TestCase):
             stats={'rows':1000}
         )
         registry.save_dataset_revision(response)
-        ret = registry.get_revision_by_dataset_id('non-existing')
+        ret = registry.get_revision('non-existing')
         self.assertIsNone(ret)
         # check by dataset_id
-        ret = registry.get_revision_by_dataset_id('datahub/id')
+        ret = registry.get_revision('datahub/id')
         self.assertEqual(response, ret)
         # check by revision_id
         response['revision_id'] = 'datahub/id/101'
@@ -74,10 +74,10 @@ class ModelsTestCase(unittest.TestCase):
 
     def test_create_revision(self):
         registry.create_revision('datahub/revision', now, 'pending', [])
-        ret = registry.get_revision_by_dataset_id('datahub/revision')
+        ret = registry.get_revision('datahub/revision')
         self.assertEqual(ret['revision'], 1)
         registry.create_revision('datahub/revision', now, 'success', ['error'])
-        ret = registry.get_revision_by_dataset_id('datahub/revision')
+        ret = registry.get_revision('datahub/revision')
         self.assertEqual(ret['revision'], 2)
 
     def test_update_revision(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,6 +56,7 @@ class ModelsTestCase(unittest.TestCase):
             created_at=now,
             updated_at=now,
             status='success',
+            pipelines=None,
             errors=['some not useful errors'],
             logs=['a','log','line'],
             stats={'rows':1000}
@@ -95,6 +96,7 @@ class ModelsTestCase(unittest.TestCase):
         response = dict(
             pipeline_id = 'datahub/dataset',
             flow_id = '1/datahub/id',
+            title=None,
             pipeline_details = [],
             status = 'success',
             errors = [],
@@ -113,6 +115,7 @@ class ModelsTestCase(unittest.TestCase):
         response = dict(
             pipeline_id = 'datahub/pipelines',
             flow_id = '2/datahub/id',
+            title=None,
             pipeline_details = [],
             status = 'failed',
             errors = [],


### PR DESCRIPTION
**WIP**

Changes to specstore for data validation:

* Get info of specific revision of flow (revision)
  * merge `status` and `info` endpoints -> `{owner}/{dataset}/{revision-id}`
  * README and tests updated
* Updated pipeline statuses in correct way PENDING, RUNNING, FAILED, SUCCESS (see commit message for more info)
* Upload API return `flow_id` together with `dataset_id` 
  * README updated