### PR TITLE
[metastore][s]: export meta for failed revision if successful not exists #35

### DIFF
--- a/flowmanager/controllers.py
+++ b/flowmanager/controllers.py
@@ -216,8 +216,13 @@ class PipelineStatusCallback:
 
                     }       # Other payload
                 )
-            if flow_status == STATE_SUCCESS:
+
+            no_succesful_revision = registry.get_revision(revision['dataset_id'], 'successful') is None
+
+            if flow_status == STATE_SUCCESS or no_succesful_revision:
                 descriptor : dict = get_descriptor(flow_id)
+                if no_succesful_revision and descriptor['datahub'].get('findability') == 'published':
+                    descriptor['datahub']['findability'] = 'unlisted'
                 if descriptor is not None:
                     send_dataset(
                         descriptor.get('id'),

--- a/flowmanager/controllers.py
+++ b/flowmanager/controllers.py
@@ -221,9 +221,9 @@ class PipelineStatusCallback:
 
             if flow_status == STATE_SUCCESS or no_succesful_revision:
                 descriptor : dict = get_descriptor(flow_id)
-                if no_succesful_revision and descriptor['datahub'].get('findability') == 'published':
-                    descriptor['datahub']['findability'] = 'unlisted'
                 if descriptor is not None:
+                    if no_succesful_revision and descriptor['datahub'].get('findability') == 'published':
+                        descriptor['datahub']['findability'] = 'unlisted'
                     send_dataset(
                         descriptor.get('id'),
                         descriptor.get('name'),


### PR DESCRIPTION
To track total numbers of datasets correctly, we need to export metadata of failed revisions that has no successful revision. This PR makes it possible. 