### PR TITLE
[specs][s]: include create_time in spec meta fixes #38

### DIFF
--- a/flowmanager/config.py
+++ b/flowmanager/config.py
@@ -25,3 +25,6 @@ def dataset_getter(spec):
 
 def update_time_setter(spec, now: datetime.datetime):
     spec['meta']['update_time'] = now.isoformat()
+
+def create_time_setter(spec, create: datetime.datetime):
+    spec['meta']['create_time'] = create.isoformat()

--- a/flowmanager/controllers.py
+++ b/flowmanager/controllers.py
@@ -13,7 +13,7 @@ from dpp_runner.lib import DppRunner
 
 from .schedules import parse_schedule
 from .config import dpp_module
-from .config import dataset_getter, owner_getter, update_time_setter
+from .config import dataset_getter, owner_getter, update_time_setter, create_time_setter
 from .config import verbosity
 from .datasets import send_dataset
 from .models import FlowRegistry, STATE_PENDING, STATE_SUCCESS, STATE_FAILED, STATE_RUNNING
@@ -41,8 +41,8 @@ def _internal_upload(owner, contents, registry, config=CONFIGS):
 
     flow_id = None
     dataset_id = registry.format_identifier(owner, dataset_name)
-    registry.create_or_update_dataset(
-        dataset_id, owner, contents, now)
+    dataset_obj = registry.create_or_update_dataset(dataset_id, owner, contents, now)
+    create_time_setter(contents, dataset_obj.get('created_at'))
     period_in_seconds, schedule_errors = parse_schedule(contents)
     if len(schedule_errors) == 0:
         registry.update_dataset_schedule(dataset_id, period_in_seconds, now)

--- a/flowmanager/models.py
+++ b/flowmanager/models.py
@@ -127,6 +127,7 @@ class FlowRegistry:
         with self.session_scope() as session:
             dataset = Dataset(**dataset)
             session.add(dataset)
+            return FlowRegistry.object_as_dict(dataset)
 
     def get_dataset(self, identifier):
         with self.session_scope() as session:
@@ -153,6 +154,7 @@ class FlowRegistry:
                 for key, value in doc.items():
                     setattr(ret, key, value)
             session.commit()
+            return FlowRegistry.object_as_dict(ret)
 
     def create_or_update_dataset(self, identifier, owner, spec, updated_at):
         dataset = self.get_dataset(identifier)
@@ -164,9 +166,9 @@ class FlowRegistry:
         }
         if dataset is None:
             document['created_at'] = updated_at
-            self.save_dataset(document)
+            return self.save_dataset(document)
         else:
-            self.update_dataset(identifier, document)
+            return self.update_dataset(identifier, document)
 
     def update_dataset_schedule(self, identifier, period_in_seconds, now):
         dataset = self.get_dataset(identifier)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -415,11 +415,11 @@ def test_upload_new(empty_registry: FlowRegistry):
         assert revision['revision'] == 1
         assert revision['status'] == 'pending'
         pipelines = list(empty_registry.list_pipelines_by_id('me/id/1'))
-        assert len(pipelines) == 7
+        assert len(pipelines) == 8
         pipeline = pipelines[0]
         assert pipeline.status == 'pending'
         pipelines = list(empty_registry.list_pipelines())
-        assert len(pipelines) == 7
+        assert len(pipelines) == 8
 
 
 def test_upload_existing(full_registry):
@@ -442,14 +442,14 @@ def test_upload_existing(full_registry):
         assert revision['revision'] == 2
         assert revision['status'] == 'pending'
         pipelines = list(full_registry.list_pipelines_by_id('me/id/2'))
-        assert len(pipelines) == 7
+        assert len(pipelines) == 8
         pipeline = pipelines[0]
         assert pipeline.status == 'pending'
         ## make pipelines for previous revision are still there
         pipelines = list(full_registry.list_pipelines_by_id('me/id/1'))
         assert len(pipelines) == 2
         pipelines = list(full_registry.list_pipelines())
-        assert len(pipelines) == 9
+        assert len(pipelines) == 10
 
 
 def test_upload_append(full_registry):
@@ -478,11 +478,11 @@ def test_upload_append(full_registry):
         assert revision['revision'] == 1
         assert revision['status'] == 'pending'
         pipelines = list(full_registry.list_pipelines_by_id('me2/id2/1'))
-        assert len(pipelines) == 7
+        assert len(pipelines) == 8
         pipelines = list(full_registry.list_pipelines_by_id('me/id/1'))
         assert len(pipelines) == 2
         pipelines = list(full_registry.list_pipelines())
-        assert len(pipelines) == 9
+        assert len(pipelines) == 10
 
 def test_update_running(full_registry):
     payload = {

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -65,8 +65,8 @@ def empty_registry():
 @pytest.fixture
 def full_registry():
     r = FlowRegistry('sqlite://')
-    r.save_dataset(dict(identifier='me/id', owner='me', spec=spec, updated_at=now))
-    r.save_dataset(dict(identifier='you/id', owner='you', spec=spec, updated_at=now))
+    r.save_dataset(dict(identifier='me/id', owner='me', spec=spec, updated_at=now, created_at=now))
+    r.save_dataset(dict(identifier='you/id', owner='you', spec=spec, updated_at=now, created_at=now))
     r.save_dataset_revision(dict(
         revision_id='me/id/1',
         dataset_id='me/id',
@@ -408,6 +408,8 @@ def test_upload_new(empty_registry: FlowRegistry):
         first = specs[0]
         assert first.owner == 'me'
         assert first.identifier == 'me/id'
+        # create_time is set to meta only after it's created. So it's not present in DB
+        del spec['meta']['create_time']
         assert first.spec == spec
         revision = empty_registry.get_revision('me/id')
         assert revision['revision'] == 1
@@ -434,6 +436,7 @@ def test_upload_existing(full_registry):
         first = specs[0]
         assert first.owner == 'me'
         assert first.identifier == 'me/id'
+        del spec['meta']['create_time']
         assert first.spec == spec
         revision = full_registry.get_revision('me/id')
         assert revision['revision'] == 2
@@ -464,6 +467,7 @@ def test_upload_append(full_registry):
 
         assert first.owner == 'me2'
         assert first.identifier == 'me2/id2'
+        del spec2['meta']['create_time']
         assert first.spec == spec2
         second = specs[0]
         assert second.owner == 'me'


### PR DESCRIPTION
Includes `crete_time` in meta of `sourcespec`